### PR TITLE
feat(menu): simplify calculations for selection

### DIFF
--- a/lua/care/menu/init.lua
+++ b/lua/care/menu/init.lua
@@ -233,19 +233,15 @@ end
 
 function Menu:select_next(count)
     count = count or 1
-    self.index = self.index + count
-    if self.index > #self.entries then
-        self.index = self.index - #self.entries - 1
-    end
+    self.index = (self.index + count) % (#self.entries + 1)
+
     self:select(1)
 end
 
 function Menu:select_prev(count)
     count = count or 1
-    self.index = self.index - count
-    if self.index < 0 then
-        self.index = #self.entries + self.index + 1
-    end
+    self.index = (self.index - count) % (#self.entries + 1)
+
     self:select(-1)
 end
 


### PR DESCRIPTION
When using a negative count for `Menu:select_next` don't go into negative indices instead rollover to the last entry.

This simplifies for example the following logic:
```lua
local next = function(direction, key)
  return function()
    if care.api.is_open() then
      -- Post PR
      care.api.select_next(direction)

      -- Pre PR
      -- if direction >= 0 then
      --   care.api.select_next(direction)
      -- else
      --   care.api.select_prev(-direction)
      -- end
    elseif vim.snippet.active { direction = direction } then
      vim.snippet.jump(direction)
    elseif key ~= nil then
      vim.api.nvim_feedkeys(vim.keycode(key), "n", false)
    else
      care.api.complete()
    end
  end
end

vim.keymap.set("i", "<c-n>", next(1))
vim.keymap.set("i", "<c-p>", next(-1))
```