### PR TITLE
fix: Correct the misspelled words in README.md and health.lua

### DIFF
--- a/lua/care/health.lua
+++ b/lua/care/health.lua
@@ -74,17 +74,17 @@ function Health.check()
             vim.health.error(error)
         end
     end
-    vim.health.info("Aligments:")
-    local wrong_aligments = false
+    vim.health.info("Alignments:")
+    local wrong_alignments = false
     for i, alignment in ipairs(require("care.config").options.ui.menu.alignments) do
         if not vim.tbl_contains({ nil, "left", "right", "center" }, alignment) then
             vim.health.error(
-                "Field number " .. i .. ' in the aligments table is an invalid aligment ("' .. alignment .. '")'
+                "Field number " .. i .. ' in the alignments table is an invalid alignment ("' .. alignment .. '")'
             )
-            wrong_aligments = true
+            wrong_alignments = true
         end
     end
-    if not wrong_aligments then
+    if not wrong_alignments then
         vim.health.info("All alignments are correct")
     end
     vim.health.info("")

--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,13 @@
 # ✨ Features
 
 -   Fully configurable menu
--   Api for keybindings and various utilities
+-   API for keybindings and various utilities
 -   [Different presets](https://max397574.github.io/care.nvim/presets) for the
     menu
 -   [Components](https://max397574.github.io/care.nvim/preset_components) and
     [utilities](https://max397574.github.io/care.nvim/preset_utils) for easy
     configuration of menu
--   Compability with nvim-cmp sources with
+-   Compatibility with nvim-cmp sources with
     [care-cmp](https://github.com/max397574/care-cmp)
 -   Really fast performance (can draw thousands of items per keystroke without
     problems)
@@ -27,7 +27,7 @@
 # 🚀 Getting started
 
 You can simply install care.nvim with your preferred plugin manager. There are
-builtin sources for lsp and more comming soon.
+builtin sources for lsp and more coming soon.
 
 Care is initialized automatically and lazy-loaded internally so there is no need
 for lazy-loading nor calling setup.


### PR DESCRIPTION
Fixes:
- corrected all the misspelled words in README.md and lua/care/health.lua
- changed the name of the variable from 'wrong_aligments' to 'wrong_alignments'