### PR TITLE
hide markdown links from vim.lsp.util.stylize_markdown

### DIFF
--- a/lua/care/menu/init.lua
+++ b/lua/care/menu/init.lua
@@ -108,7 +108,20 @@ Menu.draw_docs = require("care.utils.async").throttle(function(self, entry)
                 vim.api.nvim_buf_set_lines(self.docs_window.buf, 0, -1, false, {})
             end)
 
-            vim.lsp.util.stylize_markdown(self.docs_window.buf, docs, { max_width = width })
+            local stylize_markdown = function(bufnr, contents, opts)
+                local new_contents = {}
+
+                -- Filter out links/anchors
+                for _, line in ipairs(contents) do
+                    -- Remove markdown links like [text](url) and ![text](url)
+                    local cleaned_line = line:gsub("!?%b[]%b()", "")
+                    table.insert(new_contents, cleaned_line)
+                end
+
+                return vim.lsp.util.stylize_markdown(bufnr, new_contents, opts)
+            end
+
+            stylize_markdown(self.docs_window.buf, docs, { max_width = width })
         end
 
         width = math.min(width, require("care.utils").longest(docs))


### PR DESCRIPTION

Hello there, author.

In this pull request, I have implemented a way to get rid of anchors and links from the docs which is being stylized by vim.lsp.util.stylize_markdown.

It is a very simple implementation and I am very sure you can use this same code to create a better result with options or improvements.

Sincerely, matt.